### PR TITLE
Add GH action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,5 +38,5 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         name: Release ${{ github.ref_name }}
-        files: ./build/libs/HKTools-${{ github.ref_name }}.jar
+        files: ./build/libs/HKTools-*.jar
         draft: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,6 @@ jobs:
     - name: Create Release
       uses: softprops/action-gh-release@v2
       with:
-        name: Release ${{ github.ref }}
-        files: ./build/libs/HKTools-${{ github.ref }}.jar
+        name: Release ${{ github.ref_name }}
+        files: ./build/libs/HKTools-${{ github.ref_name }}.jar
         draft: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,6 @@ jobs:
     - name: Create Release
       uses: softprops/action-gh-release@v2
       with:
-        name: Release ${{ github.ref_name }}
+        name: HKtools ${{ github.ref_name }}
         files: ./build/libs/HKtools-*.jar
         draft: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,8 @@ name: 'Build Mod'
 
 on:
     push:
-    pull_request:
+        tags:
+            - 'v*'
 
 jobs:
   build:
@@ -33,8 +34,9 @@ jobs:
       run: ./gradlew build
       shell: bash
     
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
+    - name: Create Release
+      uses: softprops/action-gh-release@v2
       with:
-        name: Latest Release
-        path: ./build/libs
+        name: Release ${{ github.ref }}
+        files: ./build/libs/HKTools-${{ github.ref }}.jar
+        draft: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
     push:
         tags:
             - 'v*'
+    workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,8 @@ jobs:
     - name: Set up JDK 8
       uses: actions/setup-java@v2
       with:
-        java-version: '8'
-        distribution: 'dragonwell'
+        java-version: 8
+        distribution: 'adopt'
         
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       shell: bash
     
     - name: Create release
-      uses: actions/upload-artifact@v2
+      uses: ncipollo/release-action@v1
       with:
-        name: Artifacts
-        path: ./build/libs
+        name: Latest Release
+        artifacts: ./build/libs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: 'Build Mod'
+
+on:
+    push:
+    pull_request:
+
+jobs:
+  build:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up JDK 8
+      uses: actions/setup-java@v2
+      with:
+        java-version: '8'
+        distribution: 'dragonwell'
+        
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        gradle-version: 3.1
+
+    - name: Run chmod to make gradlew executable
+      run: chmod +x ./gradlew
+      shell: bash
+      
+    - name: Build with Gradle
+      run: ./gradlew build
+      shell: bash
+    
+    - name: Create release
+      uses: actions/upload-artifact@v2
+      with:
+        name: Artifacts
+        path: ./build/libs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,8 @@ jobs:
       run: ./gradlew build
       shell: bash
     
-    - name: Create release
-      uses: ncipollo/release-action@v1
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
       with:
         name: Latest Release
-        artifacts: ./build/libs
+        path: ./build/libs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,5 +38,5 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         name: Release ${{ github.ref_name }}
-        files: ./build/libs/HKTools-*.jar
+        files: ./build/libs/HKtools-*.jar
         draft: true


### PR DESCRIPTION
Hello! 
# Aim
I added an action which sets up java and gradle, builds the mod and uploads it to a github release (Draft). This makes development substantially easier

# How to use
To trigger it you have to create a tag matching the pattern `v*`
so if you say release 0.2.3 you enter the following commands:
`git tag v0.2.3` and then `git push --tags`
this will start the action.